### PR TITLE
Remove old next steps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,6 @@ The Open Metaverse Interoperability Group is focused on bridging virtual worlds 
 ## Our Vision
 >## We bolster the metaverse as an open and interoperable resource for anyone, inspired by the collaborative efforts of the community.
 
-## Next Steps
-
-Click on any of these links to contribute to their associated Github Discussions / Issues:
-
-- [Define key results for each of our objectives](https://github.com/omigroup/OMI/discussions/10) ✔️
-- [Appoint one or more chairs for our W3C Community Group](https://github.com/omigroup/OMI/discussions/17) ✔️
-- [Define our scope of work](https://github.com/omigroup/OMI/discussions/28)
-- [Determine what OMI's responsibilities are outside of standards/protocols](https://github.com/omigroup/OMI/discussions/31)
-- [Write up our community group charter](https://github.com/omigroup/OMI/discussions/30)
-- [Explore incentives for participation in OMI](https://github.com/omigroup/OMI/discussions/32)
-
 ## How To Get Involved
 
 Are you passionate about the metaverse? Join us! 


### PR DESCRIPTION
I don't think we need this next steps section anymore. We have a charter and have discussed all of these topics at length.